### PR TITLE
chore(ci): group GitHub Actions Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,11 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      github-actions-deps:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: docker
     directory: /hack/build/


### PR DESCRIPTION
Add `groups` configuration to Dependabot to batch GitHub Actions dependency updates into a single PR, reducing PR noise.
                                                                                                                                                                    
Example:                                                                                                                                                     
  Before this change, Dependabot would open one PR per GitHub Actions update:                                                                                       
  - `ci: bump actions/checkout from v3 to v4`                                                                                                                       
  - `ci: bump actions/setup-go from v5.0.0 to v5.1.0`                                                                                                               
  - `ci: bump actions/cache from v3 to v4`                                                                                                                          
                                                                                                                                                                    
  After this change, all GitHub Actions updates are grouped into one PR:                                                                                            
  - `ci: bump github-actions dependencies`                                                                                                                          
    - actions/checkout v3 → v4                                                                                                                                      
    - actions/setup-go v5.0.0 → v5.1.0                                                                                                                              
    - actions/cache v3 → v4   